### PR TITLE
Add support for MOCHA_WEBDRIVER_ARGS and MOCHA_WEBDRIVER_HEADLESS env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ mocha test/fooTest.ts -b --no-exit
 
 (If mocha is locally installed, run `./node_modules/.bin/mocha` or `$(npm bin)/mocha`).
 
+You may select the browser to start `SELENIUM_BROWSER=chrome|firefox` environment variable (see [selenium
+docs](https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_Builder.html)
+for other variables). Some additional environment variables are also supported:
+
+  - `MOCHA_WEBDRIVER_HEADLESS`: start browser in headless mode if set to non-empty value
+  - `MOCHA_WEBDRIVER_ARGS`: pass the given args to the browser (e.g. `--disable-gpu --foo=bar`)
+
 ## Useful methods
 
 `mocha-webdriver` provides several enhancement to the webdriver interface:

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -88,6 +88,8 @@ before(async function() {
     .setChromeOptions(chromeOpts)
     .setFirefoxOptions(firefoxOpts)
     .build();
+  // If driver fails to start, this will let us notice and abort quickly.
+  await driver.getSession();
 });
 
 // Quit the webdriver and stop serving files, unless we failed and --no-exit is given.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -68,11 +68,25 @@ before(async function() {
   // Prepend node_modules/.bin to PATH, for chromedriver/geckodriver to be found.
   process.env.PATH = path.resolve("node_modules", ".bin") + ":" + process.env.PATH;
 
+  const chromeOpts = new chrome.Options();
+  const firefoxOpts = new firefox.Options();
+
+  // Pay attention to the environment variables (documented in README).
+  if (process.env.MOCHA_WEBDRIVER_HEADLESS) {
+    chromeOpts.headless();
+    firefoxOpts.headless();
+  }
+  if (process.env.MOCHA_WEBDRIVER_ARGS) {
+    const args = process.env.MOCHA_WEBDRIVER_ARGS.trim().split(/\s+/);
+    chromeOpts.addArguments(...args);
+    firefoxOpts.addArguments(...args);
+  }
+
   driver = new Builder()
     .forBrowser('firefox')
     .setLoggingPrefs(logPrefs)
-    .setChromeOptions(new chrome.Options())
-    .setFirefoxOptions(new firefox.Options())
+    .setChromeOptions(chromeOpts)
+    .setFirefoxOptions(firefoxOpts)
     .build();
 });
 


### PR DESCRIPTION
This will allow running mocha-webdriver in an environment like docker.