### PR TITLE
Add support for MOCHA_WEBDRIVER_MAX_CALLS variable to limit in-flight selenium calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ for other variables). Some additional environment variables are also supported:
 
   - `MOCHA_WEBDRIVER_HEADLESS`: start browser in headless mode if set to non-empty value
   - `MOCHA_WEBDRIVER_ARGS`: pass the given args to the browser (e.g. `--disable-gpu --foo=bar`)
-  - `MOCHA_WEBDRIVER_MAX_CALLS`: limit the number of parallel selenium calls to this number, e.g. 3.
+  - `MOCHA_WEBDRIVER_MAX_CALLS`: limit the number of parallel selenium calls to this number, e.g. `5`.
 You can use this to work around an
 [issue](https://github.com/SeleniumHQ/selenium/issues/5611) in
 [selenium-standalone](https://github.com/vvo/selenium-standalone), causing "Connection reset" errors.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ for other variables). Some additional environment variables are also supported:
 
   - `MOCHA_WEBDRIVER_HEADLESS`: start browser in headless mode if set to non-empty value
   - `MOCHA_WEBDRIVER_ARGS`: pass the given args to the browser (e.g. `--disable-gpu --foo=bar`)
+  - `MOCHA_WEBDRIVER_MAX_CALLS`: limit the number of parallel selenium calls to this number, e.g. 3.
+You can use this to work around an
+[issue](https://github.com/SeleniumHQ/selenium/issues/5611) in
+[selenium-standalone](https://github.com/vvo/selenium-standalone), causing "Connection reset" errors.
 
 ## Useful methods
 
@@ -130,6 +134,10 @@ method. E.g. `await driver.find('#btn').mouseMove({x: 100}).doClick()`.
 ### elem.hasFocus()
 
 Returns whether this element is the current activeElement.
+
+### elem.isPresent()
+
+Returns whether this element is present in the DOM of the current page.
 
 ### driver.mouseDown(button?), driver.mouseUp(button?)
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -99,7 +99,7 @@ before(async function() {
   await driver.getSession();
 
   // If requested, limit the max number of parallel in-flight selenium calls. This is needed for
-  // selenium-standalone, which can't cope with more than a few calls. A limit like 3 works fine.
+  // selenium-standalone, which can't cope with more than a few calls. A limit like 5 works fine.
   // See also https://github.com/SeleniumHQ/selenium/issues/5611
   if (process.env.MOCHA_WEBDRIVER_MAX_CALLS) {
     const count = parseInt(process.env.MOCHA_WEBDRIVER_MAX_CALLS, 10);

--- a/lib/serialize-calls.ts
+++ b/lib/serialize-calls.ts
@@ -1,0 +1,45 @@
+/**
+ * selenium-standalone is limited to how many parallel calls it can handle. A call such as
+ * findAll(selector, (el) => e.getText()) could easily exceed that limit and cause "Connection
+ * reset" errors. (See also https://github.com/SeleniumHQ/selenium/issues/5611)
+ *
+ * This file implements throttling of calls, to ensure that at most maxPendingCalls are
+ * outstanding at any given time. It can be applied to any promise-returning method.
+ */
+
+type PromiseFunc = (...args: any[]) => Promise<any>;
+
+export function serializeCalls<Func extends PromiseFunc>(method: Func, maxPendingCalls: number): Func {
+  // Queue of all calls that haven't yet started. Calling a callback here starts the call.
+  const queue: Array<() => any> = [];
+
+  // Number of calls we've made and are waiting to get resolved.
+  let running: number = 0;
+
+  // Wrapped version of the passed-in method.
+  function serializedMethod(this: any, ...args: any[]) {
+    const ready = new Promise((resolve) => queue.push(resolve));
+
+    // If we can make a call immediately, checkQueue() will call the resolver, so that ready will
+    // be an already-resolved promise.
+    checkQueue();
+
+    return ready.then(async () => {
+      try {
+        return await method.call(this, ...args);
+      } finally {
+        // Once the method returns, check if we can process the next queued call.
+        running -= 1;
+        checkQueue();
+      }
+    });
+  }
+
+  function checkQueue() {
+    if (running >= maxPendingCalls) { return; }
+    const nextReady = queue.shift();
+    if (nextReady) { running += 1; nextReady(); }
+  }
+
+  return serializedMethod as Func;
+}

--- a/test/test-serialize-calls.ts
+++ b/test/test-serialize-calls.ts
@@ -1,0 +1,101 @@
+import {assert} from '../lib';
+import {serializeCalls} from '../lib/serialize-calls';
+
+interface IResolver {
+  resolve(value: string): void;
+  reject(err: Error): void;
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('serialize-calls', () => {
+  it('should serialize calls', async () => {
+    // The test for serializeCalls is a bit tricky. We make in parallel a bunch of calls: each one
+    // will add an event to the events array when it starts and when it resolves or fails.
+    const calls = new Map<string, IResolver>();
+    const events: string[] = [];
+
+    // This is a "call": we can tell when it was made and when it finished by looking at the
+    // events array.
+    async function makeCall(id: string): Promise<void> {
+      events.push(`${id} called`);
+      try {
+        const r = await new Promise<string>((resolve, reject) => calls.set(id, {resolve, reject}));
+        events.push(`${id} returned ${r}`);
+      } catch (err) {
+        events.push(`${id} threw ${err.message}`);
+      }
+    }
+
+    // While the calls are pending, we run also this "resolver" function, which resolves the calls
+    // with the given IDs in the specified order. Depending on the ID, it may reject a call
+    // instead, to test that errors are processed as well.
+    async function resolveCalls(ids: string[]): Promise<void> {
+      for (const id of ids) {
+        await delay(1);
+        if (id.startsWith('Err')) {
+          calls.get(id)!.reject(new Error(id.toUpperCase()));
+        } else {
+          calls.get(id)!.resolve(id.toUpperCase());
+        }
+        calls.delete(id);
+      }
+    }
+
+    // With the plain call, all calls are made at once, and resolved in whatever order we
+    // specified. This is to show that this test is doing what we want.
+    await Promise.all([
+      Promise.all(['a1', 'a2', 'a3', 'a4', 'a5', 'Err1', 'a6', 'Err2'].map(makeCall)),
+      resolveCalls(['a1', 'a3', 'a4', 'a2', 'Err1', 'a5', 'a6', 'Err2']),
+    ]);
+    assert.deepEqual(events, [
+      "a1 called",
+      "a2 called",
+      "a3 called",
+      "a4 called",
+      "a5 called",
+      "Err1 called",
+      "a6 called",
+      "Err2 called",
+      "a1 returned A1",
+      "a3 returned A3",
+      "a4 returned A4",
+      "a2 returned A2",
+      "Err1 threw ERR1",
+      "a5 returned A5",
+      "a6 returned A6",
+      "Err2 threw ERR2",
+    ]);
+
+    // Clear the events array.
+    events.splice(0, events.length);
+
+    // The actual test is of the serialized version of makeCall. The resolutions are in the same
+    // order, but calls are only made to keep at most 3 in-progress calls.
+    const serializedMakeCall = serializeCalls(makeCall, 3);
+    await Promise.all([
+      Promise.all(['a1', 'a2', 'a3', 'a4', 'a5', 'Err1', 'a6', 'Err2'].map(serializedMakeCall)),
+      resolveCalls(['a1', 'a3', 'a4', 'a2', 'Err1', 'a5', 'a6', 'Err2']),
+    ]);
+    assert.deepEqual(events, [
+      "a1 called",
+      "a2 called",
+      "a3 called",
+      "a1 returned A1",
+      "a4 called",
+      "a3 returned A3",
+      "a5 called",
+      "a4 returned A4",
+      "Err1 called",
+      "a2 returned A2",
+      "a6 called",
+      "Err1 threw ERR1",
+      "Err2 called",
+      "a5 returned A5",
+      "a6 returned A6",
+      "Err2 threw ERR2",
+    ]);
+  });
+});


### PR DESCRIPTION
This can be used to work around an issue in selenium-standalone that causes "connection reset" errors when many selenium calls are made in parallel.

The fix isn't auto-tested directly (but there is a unittest for the logic involved). It was tested manually using `driver.findAll(..., (el) => el.getText())` for 34 elements, running against selenium-standalone (v6.16.0). When running directly, 6 runs out of 10 had an error. When running with `MOCHA_WEBDRIVER_MAX_CALLS=5`, all 10 runs passed.