### PR TITLE
Add saving of logs on test failure, and related utilities.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ for other variables). Some additional environment variables are also supported:
 You can use this to work around an
 [issue](https://github.com/SeleniumHQ/selenium/issues/5611) in
 [selenium-standalone](https://github.com/vvo/selenium-standalone), causing "Connection reset" errors.
-  - `MW_SCREENSHOT_DIR`: in conjunction with [setupScreenshots](#setupscreenshotsdriver), a
-directory into which to save screenshots automatically after any failed test case.
+  - `MOCHA_WEBDRIVER_LOGDIR`: in conjunction with [setUpDebugCapture](#setupdebugcapture), a
+directory into which to save logs and screenshots automatically after any failed test case.
+  - `MOCHA_WEBDRIVER_LOGTYPES`: comma-separated list of which [log types](https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/lib/logging_exports_Type.html)
+to enable, for `driver.fetchLogs()` and for `setUpDebugCapture()`. Defaults to `browser,driver`.
 
 ## Useful methods
 
@@ -175,14 +177,16 @@ available name. (While `relPath` may includes subdirectories, the `{N}` token
 may only be used in the filename part.)
  - `dir` may specify a different destination directory. If empty, the screenshot will be skipped.
 
-### setupScreenshots()
+### setUpDebugCapture()
 
-If called in a mocha test suite (i.e. inside `describe()`), adds an `afterEach` hook to save a
-screenshot after any failed test, only if `MW_SCREENSHOT_DIR` variable is set. The image is named
-`MW_SCREENSHOT_DIR/screenshot-{name}-{N}.png`, where `name` is the basename of the test file, and
-`N` is a numeric suffix.
+If called in a mocha test suite (i.e. inside `describe()`), adds an `afterEach` hook to save logs
+and a screenshot after any failed test, only if `MOCHA_WEBDRIVER_LOGDIR` variable is set. The
+files are named:
+  - `MOCHA_WEBDRIVER_LOGDIR/{name}-{logtype}-{N}.log`
+  - `MOCHA_WEBDRIVER_LOGDIR/{name}-screenshot-{N}.png`,
+where `name` is the basename of the test file, and `N` is a numeric suffix.
 
-This is helpful for debugging when running tests in headless mode.
+This is helpful for debugging failing tests. Screenshots are particularly helpful in headless mode.
 
 ## Debugging tests
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ for other variables). Some additional environment variables are also supported:
 You can use this to work around an
 [issue](https://github.com/SeleniumHQ/selenium/issues/5611) in
 [selenium-standalone](https://github.com/vvo/selenium-standalone), causing "Connection reset" errors.
-  - `MOCHA_WEBDRIVER_LOGDIR`: in conjunction with [setUpDebugCapture](#setupdebugcapture), a
+  - `MOCHA_WEBDRIVER_LOGDIR`: in conjunction with [enableDebugCapture](#enabledebugcapture), a
 directory into which to save logs and screenshots automatically after any failed test case.
   - `MOCHA_WEBDRIVER_LOGTYPES`: comma-separated list of which [log types](https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/lib/logging_exports_Type.html)
-to enable, for `driver.fetchLogs()` and for `setUpDebugCapture()`. Defaults to `browser,driver`.
+to enable, for `driver.fetchLogs()` and for `enableDebugCapture()`. Defaults to `browser,driver`.
 (Note: Supported by Chrome, but not Firefox, as of June 2019.)
 
 ## Useful methods
@@ -178,7 +178,7 @@ available name. (While `relPath` may includes subdirectories, the `{N}` token
 may only be used in the filename part.)
  - `dir` may specify a different destination directory. If empty, the screenshot will be skipped.
 
-### setUpDebugCapture()
+### enableDebugCapture()
 
 If called in a mocha test suite (i.e. inside `describe()`), adds an `afterEach` hook to save logs
 and a screenshot after any failed test, only if `MOCHA_WEBDRIVER_LOGDIR` variable is set. The

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ You can use this to work around an
 directory into which to save logs and screenshots automatically after any failed test case.
   - `MOCHA_WEBDRIVER_LOGTYPES`: comma-separated list of which [log types](https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/lib/logging_exports_Type.html)
 to enable, for `driver.fetchLogs()` and for `setUpDebugCapture()`. Defaults to `browser,driver`.
+(Note: Supported by Chrome, but not Firefox, as of June 2019.)
 
 ## Useful methods
 

--- a/lib/debugging.ts
+++ b/lib/debugging.ts
@@ -1,0 +1,44 @@
+/**
+ * Functions to aid debugging, such as for saving screenshots and logs.
+ */
+import * as path from 'path';
+import {driver} from './index';
+import {getEnabledLogTypes, saveLogs} from './logs';
+
+/**
+ * Adds an afterEach() hook to the current test suite to save logs and screenshots after failed
+ * tests. These are saved only if `MOCHA_WEBDRIVER_LOGDIR` variable is set, and named:
+ *  - MOCHA_WEBDRIVER_LOGDIR/{testBaseName}-{logtype}.log
+ *  - MOCHA_WEBDRIVER_LOGDIR/{testBaseName}-screenshot-{N}.png
+ *
+ * This should be called at suite level, not at root level (as this hook is only suitable for some
+ * kinds of mocha tests, namely those using webdriver).
+ */
+export function setUpDebugCapture() {
+  beforeEach(async function() {
+    if (this.runnable().parent!.root) {
+      throw new Error("setupSnapshots() should be called at suite level, not at root level");
+    }
+
+    // Fetches logs without saving them, in effect discarding all messages so far, so that the
+    // saveLogs() call in afterEach() gets only the messages created during this test case.
+    for (const logType of getEnabledLogTypes()) {
+      await driver.fetchLogs(logType);
+    }
+  });
+
+  afterEach(async function() {
+    // Take snapshots after each failed test case.
+    const test = this.currentTest!;
+    if (test.state !== 'passed' && !test.pending) {
+      // If test filename is available, name screenshots as "screenshot-testName-N.png"
+      const testName = test.file ? path.basename(test.file, path.extname(test.file)) : "unnamed";
+      // This is a no-op if MOCHA_WEBDRIVER_LOGDIR is not set.
+      await driver.saveScreenshot(`${testName}-screenshot-{N}.png`);
+      for (const logType of getEnabledLogTypes()) {
+        const messages = await driver.fetchLogs(logType);
+        await saveLogs(messages, `${testName}-${logType}-{N}.log`);
+      }
+    }
+  });
+}

--- a/lib/debugging.ts
+++ b/lib/debugging.ts
@@ -22,8 +22,10 @@ export function setUpDebugCapture() {
 
     // Fetches logs without saving them, in effect discarding all messages so far, so that the
     // saveLogs() call in afterEach() gets only the messages created during this test case.
-    for (const logType of getEnabledLogTypes()) {
-      await driver.fetchLogs(logType);
+    if (process.env.MOCHA_WEBDRIVER_LOGDIR) {
+      for (const logType of getEnabledLogTypes()) {
+        await driver.fetchLogs(logType);
+      }
     }
   });
 
@@ -33,11 +35,12 @@ export function setUpDebugCapture() {
     if (test.state !== 'passed' && !test.pending) {
       // If test filename is available, name screenshots as "screenshot-testName-N.png"
       const testName = test.file ? path.basename(test.file, path.extname(test.file)) : "unnamed";
-      // This is a no-op if MOCHA_WEBDRIVER_LOGDIR is not set.
-      await driver.saveScreenshot(`${testName}-screenshot-{N}.png`);
-      for (const logType of getEnabledLogTypes()) {
-        const messages = await driver.fetchLogs(logType);
-        await saveLogs(messages, `${testName}-${logType}-{N}.log`);
+      if (process.env.MOCHA_WEBDRIVER_LOGDIR) {
+        await driver.saveScreenshot(`${testName}-screenshot-{N}.png`);
+        for (const logType of getEnabledLogTypes()) {
+          const messages = await driver.fetchLogs(logType);
+          await saveLogs(messages, `${testName}-${logType}-{N}.log`);
+        }
       }
     }
   });

--- a/lib/debugging.ts
+++ b/lib/debugging.ts
@@ -14,10 +14,10 @@ import {getEnabledLogTypes, saveLogs} from './logs';
  * This should be called at suite level, not at root level (as this hook is only suitable for some
  * kinds of mocha tests, namely those using webdriver).
  */
-export function setUpDebugCapture() {
+export function enableDebugCapture() {
   beforeEach(async function() {
     if (this.runnable().parent!.root) {
-      throw new Error("setupSnapshots() should be called at suite level, not at root level");
+      throw new Error("enableDebugCapture() should be called at suite level, not at root level");
     }
 
     // Fetches logs without saving them, in effect discarding all messages so far, so that the

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -25,7 +25,7 @@ export {assert} from 'chai';
 export * from 'selenium-webdriver';
 
 // Re-export function that sets up an afterEach() hook to save screenshots of failed tests.
-export {setUpDebugCapture} from './debugging';
+export {enableDebugCapture} from './debugging';
 export {LogType, logTypes} from './logs';
 
 /**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,6 +6,7 @@ import * as repl from 'repl';
 import {Builder, logging, WebDriver, WebElement} from 'selenium-webdriver';
 import * as chrome from 'selenium-webdriver/chrome';
 import * as firefox from 'selenium-webdriver/firefox';
+import {getEnabledLogTypes} from './logs';
 import {serializeCalls} from './serialize-calls';
 import "./webdriver-plus";
 
@@ -24,7 +25,8 @@ export {assert} from 'chai';
 export * from 'selenium-webdriver';
 
 // Re-export function that sets up an afterEach() hook to save screenshots of failed tests.
-export {setupScreenshots} from './screenshots';
+export {setUpDebugCapture} from './debugging';
+export {LogType, logTypes} from './logs';
 
 /**
  * Use `import {driver} from 'webdriver-mocha'. Note that it's already enhanced with extra methods
@@ -73,7 +75,9 @@ before(async function() {
 
   // Set up browser options.
   const logPrefs = new logging.Preferences();
-  logPrefs.setLevel(logging.Type.BROWSER, logging.Level.INFO);
+  for (const logType of getEnabledLogTypes()) {
+    logPrefs.setLevel(logType, logging.Level.INFO);
+  }
 
   // Prepend node_modules/.bin to PATH, for chromedriver/geckodriver to be found.
   process.env.PATH = path.resolve("node_modules", ".bin") + ":" + process.env.PATH;

--- a/lib/logs.ts
+++ b/lib/logs.ts
@@ -1,0 +1,48 @@
+import * as fse from 'fs-extra';
+import * as path from 'path';
+
+import {WebDriver} from './index';
+import {createNumberedFile} from './numbered-file';
+
+// Log types supported by webdriver/
+export type LogType = "browser"|"client"|"driver"|"performance"|"server";
+export const logTypes: LogType[] = ["browser", "client", "driver", "performance", "server"];
+
+/**
+ * This implementation is publicly available as driver.saveScreenshot().
+ */
+export async function _fetchLogs(this: WebDriver, type: LogType = 'driver'): Promise<string[]> {
+  const messages = await this.manage().logs().get(type);
+  return messages.map((m) => JSON.stringify(m));
+}
+
+// Parses the comma-separated MOCHA_WEBDRIVER_LOGTYPES, and returns the list of LogTypes. Defaults
+// to ["browser", "driver"].
+export function getEnabledLogTypes(): LogType[] {
+  const strTypes = (process.env.MOCHA_WEBDRIVER_LOGTYPES == null) ? "browser,driver" :
+    process.env.MOCHA_WEBDRIVER_LOGTYPES;
+
+  const types = strTypes.split(',')
+    .map((val) => val.trim().toLowerCase())
+    .filter((val) => val) as LogType[];
+  for (const t of types) {
+    if (!logTypes.includes(t as LogType)) {
+      throw new Error(`LogType ${t} invalid`);
+    }
+  }
+  return types;
+}
+
+// Saves the given messages to the given file relative to dir. Dir defauts to
+// MOCHA_WEBDRIVER_LOGDIR; if empty, no logs will be recorded.
+export async function saveLogs(
+  messages: string[], relPath: string, dir = process.env.MOCHA_WEBDRIVER_LOGDIR
+): Promise<string|undefined> {
+  if (dir) {
+    const pathTemplate = path.resolve(dir, relPath);
+    await fse.mkdirp(path.dirname(pathTemplate));
+    const logPath = await createNumberedFile(pathTemplate);
+    await fse.writeFile(logPath, messages.join("\n") + "\n", {flag: 'a'});
+    return logPath;
+  }
+}

--- a/lib/numbered-file.ts
+++ b/lib/numbered-file.ts
@@ -1,0 +1,36 @@
+import * as fse from 'fs-extra';
+
+// For {N} replacements below, don't try beyond N=1000. Running into it indicates a likely bug
+// somewhere, or a very inefficient solution. If you ever legitimately need so many unique files,
+// use a different solution (probably mktemp-like).
+const MAX_N_TOKEN = 1000;
+
+/**
+ * Create a file according to template, replacing "{N}" token with a numeric suffix. For example,
+ * "hello-{N}.txt" will attempt creating files named "hello-1.txt", "hello-2.txt", etc. until it
+ * finds a name that doesn't yet exist. Returns the path of the newly created empty file.
+ *
+ * If the template contains no special token, uses the template as the path itself, succeeding
+ * whether or not it exists.
+ */
+export async function createNumberedFile(template: string): Promise<string> {
+  const TOKEN = "{N}";
+  if (!template.includes(TOKEN)) {
+    // If file doesn't exist, create it, and return the path.
+    await fse.close(await fse.open(template, 'w'));
+    return template;
+  }
+
+  for (let n = 1; ; n++) {
+    const fullName = template.replace(TOKEN, String(n));
+    try {
+      // Use "x" flag (O_EXCL) to get EEXIST error if file already exists. This avoids race
+      // conditions, compared to solutions such as with fs.stat().
+      await fse.close(await fse.open(fullName, 'wx'));
+      return fullName;
+    } catch (err) {
+      if (err.code === 'EEXIST' && n < MAX_N_TOKEN) { continue; }
+      throw err;
+    }
+  }
+}

--- a/lib/screenshots.ts
+++ b/lib/screenshots.ts
@@ -3,20 +3,21 @@
  */
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import {driver, WebDriver} from './index';
+import {WebDriver} from './index';
+import {createNumberedFile} from './numbered-file';
 
 /**
- * Uses driver to take a screenshot, and saves it to MW_SCREENSHOT_DIR/screenshot-{N}.png if the
- * MW_SCREENSHOT_DIR environment variable is set.
+ * Uses driver to take a screenshot, and saves it to MOCHA_WEBDRIVER_LOGDIR/screenshot-{N}.png if the
+ * MOCHA_WEBDRIVER_LOGDIR environment variable is set.
  *
- * - relPath may specify a different destination filename, relative to MW_SCREENSHOT_DIR.
+ * - relPath may specify a different destination filename, relative to MOCHA_WEBDRIVER_LOGDIR.
  * - relPath may include "{N}" token, to replace with "1", "2", etc to find an available name.
  * - dir may specify a different destination directory. If empty, the screenshot will be skipped.
  *
  * This implementation is publicly available as driver.saveScreenshot().
  */
 export async function driverSaveScreenshot(
-  this: WebDriver, relPath = "screenshot-{N}.png", dir = process.env.MW_SCREENSHOT_DIR
+  this: WebDriver, relPath = "screenshot-{N}.png", dir = process.env.MOCHA_WEBDRIVER_LOGDIR
 ): Promise<string|undefined> {
   if (dir) {
     const imageData = await this.takeScreenshot();
@@ -26,64 +27,4 @@ export async function driverSaveScreenshot(
     await fse.writeFile(imagePath, imageData, "base64");
     return imagePath;
   }
-}
-
-// For {N} replacements below, don't try beyond N=1000. Running into it indicates a likely bug
-// somewhere, or a very inefficient solution. If you ever legitimately need so many unique files,
-// use a different solution (probably mktemp-like).
-const MAX_N_TOKEN = 1000;
-
-/**
- * Create a file according to template, replacing "{N}" token with a numeric suffix. For example,
- * "hello-{N}.txt" will attempt creating files named "hello-1.txt", "hello-2.txt", etc. until it
- * finds a name that doesn't yet exist. Returns the path of the newly created empty file.
- *
- * If the template contains no special token, uses the template as the path itself, succeeding
- * whether or not it exists.
- */
-async function createNumberedFile(template: string): Promise<string> {
-  const TOKEN = "{N}";
-  if (!template.includes(TOKEN)) {
-    // If file doesn't exist, create it, and return the path.
-    await fse.close(await fse.open(template, 'w'));
-    return template;
-  }
-
-  for (let n = 1; ; n++) {
-    const fullName = template.replace(TOKEN, String(n));
-    try {
-      // Use "x" flag (O_EXCL) to get EEXIST error if file already exists. This avoids race
-      // conditions, compared to solutions such as with fs.stat().
-      await fse.close(await fse.open(fullName, 'wx'));
-      return fullName;
-    } catch (err) {
-      if (err.code === 'EEXIST' && n < MAX_N_TOKEN) { continue; }
-      throw err;
-    }
-  }
-}
-
-/**
- * Adds an afterEach() hook to the current test suite to capture screenshots after failed tests.
- * Screenshots are only taken if MW_SCREENSHOT_DIR is set, and saved as
- * screenshot-{testName}-{N}.png files in that directory.
- *
- * This should be called at suite level, not at root level (as this hook is only suitable for some
- * kinds of mocha tests, namely those using webdriver).
- */
-export function setupScreenshots() {
-  afterEach(async function() {
-    if (this.runnable().parent!.root) {
-      throw new Error("setupSnapshots() should be called at suite level, not at root level");
-    }
-
-    // Take snapshots after each failed test case.
-    const test = this.currentTest!;
-    if (test.state !== 'passed' && !test.pending) {
-      // If test filename is available, name screenshots as "screenshot-testName-N.png"
-      const testName = test.file ? "-" + path.basename(test.file, path.extname(test.file)) : "";
-      // This is a no-op if MW_SCREENSHOT_DIR is not set.
-      await driver.saveScreenshot(`screenshot${testName}-{N}.png`);
-    }
-  });
 }

--- a/lib/webdriver-plus.ts
+++ b/lib/webdriver-plus.ts
@@ -1,6 +1,7 @@
 import {Button, By, error, until, WebDriver,
         WebElement, WebElementCondition, WebElementPromise} from 'selenium-webdriver';
 
+import {_fetchLogs, LogType} from './logs';
 import {driverSaveScreenshot} from './screenshots';
 
 // TODO: This is needed for the getRect() fix (see below).
@@ -76,6 +77,12 @@ declare module "selenium-webdriver" {
      * - dir may specify a different destination directory. If empty, the screenshot will be skipped.
      */
     saveScreenshot(relPath?: string, dir?: string): Promise<string|undefined>;
+
+    /**
+     * Fetches new log messages (since last such call) for the given LogType (e.g. "browser" or
+     * "driver"), converting it to a list of human-friendly strings.
+     */
+    fetchLogs(logType: LogType): Promise<string[]>;
   }
 
   /**
@@ -237,6 +244,7 @@ Object.assign(WebDriver.prototype, {
   },
 
   saveScreenshot: driverSaveScreenshot,
+  fetchLogs: _fetchLogs,
 });
 
 // Enhance WebElement to implement IWebElementPlus interface.

--- a/lib/webdriver-plus.ts
+++ b/lib/webdriver-plus.ts
@@ -1,7 +1,7 @@
 import {Button, By, error, until, WebDriver,
         WebElement, WebElementCondition, WebElementPromise} from 'selenium-webdriver';
 
-import {_fetchLogs, LogType} from './logs';
+import {driverFetchLogs, LogType} from './logs';
 import {driverSaveScreenshot} from './screenshots';
 
 // TODO: This is needed for the getRect() fix (see below).
@@ -244,7 +244,7 @@ Object.assign(WebDriver.prototype, {
   },
 
   saveScreenshot: driverSaveScreenshot,
-  fetchLogs: _fetchLogs,
+  fetchLogs: driverFetchLogs,
 });
 
 // Enhance WebElement to implement IWebElementPlus interface.

--- a/test/test-debugging.ts
+++ b/test/test-debugging.ts
@@ -1,0 +1,23 @@
+import * as path from 'path';
+import {assert, driver} from '../lib';
+
+describe('debugging', function() {
+  before(async function() {
+    // We can't really test the setting of MOCHA_WEBDRIVER_LOGTYPES here because it affects how
+    // the browser driver is initialized on startup.
+    await driver.get('file://' + path.resolve(__dirname, 'blank.html'));
+  });
+
+  it('should fetch requested types of logs', async function() {
+    // tslint:disable-next-line:no-console
+    await driver.executeScript(() => console.log("Hello world!"));
+
+    const logsDriver = await driver.fetchLogs('driver');
+    assert.isArray(logsDriver);
+    assert.match(logsDriver.join("\n"), /Hello world!/);
+
+    const logsBrowser = await driver.fetchLogs('browser');
+    assert.isArray(logsBrowser);
+    assert.match(logsBrowser.join("\n"), /Hello world!/);
+  });
+});

--- a/test/test-screenshots.ts
+++ b/test/test-screenshots.ts
@@ -9,13 +9,13 @@ describe('screenshots', function() {
 
   before(async function() {
     tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'test-mw-screenshots-'));
-    origScreenshotDir = process.env.MW_SCREENSHOT_DIR;
+    origScreenshotDir = process.env.MOCHA_WEBDRIVER_LOGDIR;
     await driver.get('file://' + path.resolve(__dirname, 'blank.html'));
   });
 
   after(async function() {
     // Restore the original value of the env var, in case we have other tests and care about it.
-    process.env.MW_SCREENSHOT_DIR = origScreenshotDir;
+    process.env.MOCHA_WEBDRIVER_LOGDIR = origScreenshotDir;
 
     // Check what we are removing, just to be safe.
     if (tmpDir && tmpDir.includes("screenshots")) {
@@ -23,8 +23,8 @@ describe('screenshots', function() {
     }
   });
 
-  it('should save screenshots when MW_SCREENSHOT_DIR is set', async function() {
-    process.env.MW_SCREENSHOT_DIR = tmpDir;
+  it('should save screenshots when MOCHA_WEBDRIVER_LOGDIR is set', async function() {
+    process.env.MOCHA_WEBDRIVER_LOGDIR = tmpDir;
 
     const path1 = await driver.saveScreenshot();
     assert.equal(path1, path.join(tmpDir, "screenshot-1.png"));
@@ -36,7 +36,7 @@ describe('screenshots', function() {
 
   it('should respect relPath argument when saving screenshots', async function() {
     this.timeout(10000);
-    process.env.MW_SCREENSHOT_DIR = tmpDir;
+    process.env.MOCHA_WEBDRIVER_LOGDIR = tmpDir;
 
     {
       const p = await driver.saveScreenshot('foo.png');
@@ -68,8 +68,8 @@ describe('screenshots', function() {
     }
   });
 
-  it('should not save screenshots when MW_SCREENSHOT_DIR is unset', async function() {
-    delete process.env.MW_SCREENSHOT_DIR;
+  it('should not save screenshots when MOCHA_WEBDRIVER_LOGDIR is unset', async function() {
+    delete process.env.MOCHA_WEBDRIVER_LOGDIR;
 
     const origFiles = await fse.readdir(tmpDir);
     const path1 = await driver.saveScreenshot();
@@ -77,8 +77,8 @@ describe('screenshots', function() {
     assert.deepEqual(await fse.readdir(tmpDir), origFiles);
   });
 
-  it('should save screenshots when dir is given, even with MW_SCREENSHOT_DIR unset', async function() {
-    delete process.env.MW_SCREENSHOT_DIR;
+  it('should save screenshots when dir is given, even with MOCHA_WEBDRIVER_LOGDIR unset', async function() {
+    delete process.env.MOCHA_WEBDRIVER_LOGDIR;
 
     const path1 = await driver.saveScreenshot(undefined, path.join(tmpDir, "forced"));
     assert.equal(path1, path.join(tmpDir, "forced/screenshot-1.png"));

--- a/test/test-screenshots.ts
+++ b/test/test-screenshots.ts
@@ -15,7 +15,11 @@ describe('screenshots', function() {
 
   after(async function() {
     // Restore the original value of the env var, in case we have other tests and care about it.
-    process.env.MOCHA_WEBDRIVER_LOGDIR = origScreenshotDir;
+    if (origScreenshotDir === undefined) {
+      delete process.env.MOCHA_WEBDRIVER_LOGDIR;
+    } else {
+      process.env.MOCHA_WEBDRIVER_LOGDIR = origScreenshotDir;
+    }
 
     // Check what we are removing, just to be safe.
     if (tmpDir && tmpDir.includes("screenshots")) {

--- a/test/test-webdriver-plus.ts
+++ b/test/test-webdriver-plus.ts
@@ -1,7 +1,7 @@
 import {get as getColor} from 'color-string';
 import * as path from 'path';
 import {Key, WebElement} from 'selenium-webdriver';
-import {assert, driver} from '../lib';
+import {assert, driver, setUpDebugCapture} from '../lib';
 
 function addDom(id: string, parentId?: string) {
   const parentElem = parentId ? document.getElementById(parentId) : document.body;
@@ -22,6 +22,8 @@ async function addDomDelayed(waitMs: number, id: string, parentId?: string) {
 }
 
 describe('webdriver-plus', () => {
+  setUpDebugCapture();
+
   describe('find methods', function() {
     function createDom() {
       document.body.innerHTML = `

--- a/test/test-webdriver-plus.ts
+++ b/test/test-webdriver-plus.ts
@@ -1,7 +1,7 @@
 import {get as getColor} from 'color-string';
 import * as path from 'path';
 import {Key, WebElement} from 'selenium-webdriver';
-import {assert, driver, setUpDebugCapture} from '../lib';
+import {assert, driver, enableDebugCapture} from '../lib';
 
 function addDom(id: string, parentId?: string) {
   const parentElem = parentId ? document.getElementById(parentId) : document.body;
@@ -22,7 +22,7 @@ async function addDomDelayed(waitMs: number, id: string, parentId?: string) {
 }
 
 describe('webdriver-plus', () => {
-  setUpDebugCapture();
+  enableDebugCapture();
 
   describe('find methods', function() {
     function createDom() {


### PR DESCRIPTION
Change from saving screenshots on failure to saving logs AND screenshots.

- Renaming `setupScreenshots()` to `setUpDebugCapture()`
- Saves to MOCHA_WEBDRIVER_LOGDIR if set.
- Accepts MOCHA_WEBDRIVER_LOGTYPES for which log types to enable and save.
- Adds showLogs() to REPL.
