### PR TITLE
With MOCHA_WEBDRIVER_STACKTRACES set, enhance stack traces with extra info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,10 +363,10 @@ NoSuchElementError: no such element: Unable to locate element: {"method":"css se
 }
 ```
 
-Note the lines with `[enhanced]` marker, which contains information about lines in your actual
+Note the lines with the `[enhanced]` marker, which contain information about lines in your actual
 test files.
 
 When your test code uses helper functions, stack traces may only report the location within the
 helper, and not the location of the helper's caller. To get both, you need to wrap the helper with
-`stackWrapFunc`. See also `test/helpers.ts` for an example of how to wrap an entire module of
+`stackWrapFunc()`. See also `test/helpers.ts` for an example of how to wrap an entire module of
 helpers.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You may select the browser to start `SELENIUM_BROWSER=chrome|firefox` environmen
 docs](https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_Builder.html)
 for other variables). Some additional environment variables are also supported:
 
-  - `MOCHA_WEBDRIVER_HEADLESS`: start browser in headless mode if set to non-empty value
+  - `MOCHA_WEBDRIVER_HEADLESS`: start browser in headless mode if set to a non-empty value
   - `MOCHA_WEBDRIVER_ARGS`: pass the given args to the browser (e.g. `--disable-gpu --foo=bar`)
   - `MOCHA_WEBDRIVER_WINSIZE`: start browser with the given window size, given as `WIDTHxHEIGHT` (e.g. `900x600`)
   - `MOCHA_WEBDRIVER_MAX_CALLS`: limit the number of parallel selenium calls to this number, e.g. `5`.
@@ -61,7 +61,7 @@ directory into which to save logs and screenshots automatically after any failed
   - `MOCHA_WEBDRIVER_LOGTYPES`: comma-separated list of which [log types](https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/lib/logging_exports_Type.html)
 to enable, for `driver.fetchLogs()` and for `enableDebugCapture()`. Defaults to `browser,driver`.
 (Note: Supported by Chrome, but not Firefox, as of June 2019.)
-  - `MOCHA_WEBDRIVER_STACKTRACES`: Enhance stack traces with async frames, if set to non-empty
+  - `MOCHA_WEBDRIVER_STACKTRACES`: Enhance stack traces with async frames, if set to a non-empty
 value.
 
 ## Useful methods
@@ -190,8 +190,68 @@ files are named:
 where `name` is the basename of the test file, and `N` is a numeric suffix.
 
 This is helpful for debugging failing tests. Screenshots are particularly helpful in headless mode.
+See also [#Logging](#logging).
+
+
+## Serving content
+
+As with any webdriver tests, your test is just telling a browser what to do. It's up to you to
+have a page to go to and interact with. Often such a page requires loading some client-side code
+which is the actual logic to be tested.
+
+If you'd like to build and serve such code on the fly, you have to say how to start and stop such
+a server, and mocha-webdriver provides a helper to use it, as in the following example.
+
+```typescript
+// fooTest.ts
+import {useServer} from 'mocha-webdriver';
+import {server} from './myServer';
+
+describe('fooTest', function() {
+
+  useServer(server);
+  enableDebugCapture();
+
+  before(async function() {
+    this.timeout(20000);
+    await driver.get(`${server.getHost()}/fooTest/`);
+  });
+  ...
+});
+
+//======================================================================
+// myServer.ts
+import {IMochaContext, IMochaServer} from 'mocha-webdriver';
+import * as path from 'path';
+import * as serve from 'webpack-serve';
+
+export class MyWebpackServer implements IMochaServer {
+  private _server: any;
+
+  public async start(ctx: IMochaContext) {
+    ctx.timeout(10000);   // Optionally, adjust the timeout.
+    const config = require(path.resolve(__dirname, 'webpack.config.js'));
+    this._server = await serve({}, {config});
+  }
+
+  public async stop() {
+    this._server.app.stop();
+  }
+
+  public getHost(): string {
+    const {app, options} = this._server;
+    const {port} = app.server.address();
+    return `${options.protocol}://${options.host}:${port}`;
+  }
+}
+
+export const server = new MyWebpackServer();
+```
+
 
 ## Debugging tests
+
+### REPL
 
 When you are working on a test, you can be more productive by keeping mocha running. Start it with
 ```
@@ -239,57 +299,74 @@ screen. In REPL, `screenshot()` function is available to assist with that:
 >>> screenshot("snap.png")    // saves screenshot to "./snap.png"
 ```
 
+### Logging
 
-## Serving content
+When running automated tests, if any test fails, you want to get enough information to debug it.
+To enable the collection of such info, call within your mocha test suite (i.e. inside a call to `describe()`):
 
-As with any webdriver tests, your test is just telling a browser what to do. It's up to you to
-have a page to go to and interact with. Often such a page requires loading some client-side code
-which is the actual logic to be tested.
-
-If you'd like to build and serve such code on the fly, you have to say how to start and stop such
-a server, and mocha-webdriver provides a helper to use it, as in the following example.
-
-```typescript
-// fooTest.ts
-import {useServer} from 'mocha-webdriver';
-import {server} from './myServer';
-
-describe('fooTest', function() {
-
-  useServer(server);
-
-  before(async function() {
-    this.timeout(20000);
-    await driver.get(`${server.getHost()}/fooTest/`);
-  });
-  ...
-});
-
-//======================================================================
-// myServer.ts
-import {IMochaContext, IMochaServer} from 'mocha-webdriver';
-import * as path from 'path';
-import * as serve from 'webpack-serve';
-
-export class MyWebpackServer implements IMochaServer {
-  private _server: any;
-
-  public async start(ctx: IMochaContext) {
-    ctx.timeout(10000);   // Optionally, adjust the timeout.
-    const config = require(path.resolve(__dirname, 'webpack.config.js'));
-    this._server = await serve({}, {config});
-  }
-
-  public async stop() {
-    this._server.app.stop();
-  }
-
-  public getHost(): string {
-    const {app, options} = this._server;
-    const {port} = app.server.address();
-    return `${options.protocol}://${options.host}:${port}`;
-  }
-}
-
-export const server = new MyWebpackServer();
 ```
+  enableDebugCapture();
+```
+
+In your automated running environment, set also the `MOCHA_WEBDRIVER_LOGDIR` environment variable
+to the directory to which to store debug info when a test fails.
+
+For each failed test case, you'll get a screenshot of the browser from the moment after the test
+failed, and the contents of the browser console log and of webdriver log, collected during the run
+of that test case. The logs only work on Chrome, but will contain each call to the browser, and
+its return value.
+
+### Stack Traces
+
+Node does not do a great job with stack traces from async/await code. If your test fails, you will
+typically get a stack trace like this:
+
+```
+NoSuchElementError: no such element: Unable to locate element: {"method":"css selector","selector":".nonexistent"}
+  (Session info: headless chrome=74.0.3729.169)
+  (Driver info: chromedriver=2.43.600229 (3fae4d0cda5334b4f533bede5a4787f7b832d052),platform=Mac OS X 10.13.6 x86_64)
+    at Object.checkLegacyResponse (/Users/dmitry/devel/mocha-webdriver/node_modules/selenium-webdriver/lib/error.js:585:15)
+    at parseHttpResponse (/Users/dmitry/devel/mocha-webdriver/node_modules/selenium-webdriver/lib/http.js:533:13)
+    at Executor.execute (/Users/dmitry/devel/mocha-webdriver/node_modules/selenium-webdriver/lib/http.js:468:26)
+    at processTicksAndRejections (internal/process/task_queues.js:89:5)
+    at thenableWebDriverProxy.execute (/Users/dmitry/devel/mocha-webdriver/node_modules/selenium-webdriver/lib/webdriver.js:696:17) {
+  name: 'NoSuchElementError',
+  remoteStacktrace: ''
+}
+```
+
+Note that it contains no information about which line of your test triggered it. The sample above
+is from Node 12.2.0, which has better support for async stack traces. Disappointingly, it doesn't
+help here. In Node 10, this situation occurs in more cases.
+
+At the cost of some overhead (perfectly acceptable in tests), we can do much better.
+
+Set `MOCHA_WEBDRIVER_STACKTRACES=1` environment variable, and stack traces start looking like
+this:
+
+```
+NoSuchElementError: no such element: Unable to locate element: {"method":"css selector","selector":".nonexistent"}
+  (Session info: headless chrome=74.0.3729.169)
+  (Driver info: chromedriver=2.43.600229 (3fae4d0cda5334b4f533bede5a4787f7b832d052),platform=Mac OS X 10.13.6 x86_64)
+    at Object.checkLegacyResponse (/Users/dmitry/devel/mocha-webdriver/node_modules/selenium-webdriver/lib/error.js:585:15)
+    at parseHttpResponse (/Users/dmitry/devel/mocha-webdriver/node_modules/selenium-webdriver/lib/http.js:533:13)
+    at Executor.execute (/Users/dmitry/devel/mocha-webdriver/node_modules/selenium-webdriver/lib/http.js:468:26)
+    at processTicksAndRejections (internal/process/task_queues.js:89:5)
+    at thenableWebDriverProxy.execute (/Users/dmitry/devel/mocha-webdriver/node_modules/selenium-webdriver/lib/webdriver.js:696:17)
+    at [enhanced] thenableWebDriverProxy.findElement (/Users/dmitry/devel/mocha-webdriver/node_modules/selenium-webdriver/lib/webdriver.js:911:17)
+    at [enhanced] thenableWebDriverProxy.find (/Users/dmitry/devel/mocha-webdriver/lib/webdriver-plus.ts:192:17)
+    at [enhanced] Object.helperFunc2 (/Users/dmitry/devel/mocha-webdriver/test/helpers.ts:18:18)
+    at [enhanced] Context.<anonymous> (/Users/dmitry/devel/mocha-webdriver/test/test-stackTraces.ts:75:7)
+    at [enhanced] Context.<anonymous> (/Users/dmitry/devel/mocha-webdriver/test/test-stackTraces.ts:75:13) {
+  name: 'NoSuchElementError',
+  remoteStacktrace: ''
+}
+```
+
+Note the lines with `[enhanced]` marker, which contains information about lines in your actual
+test files.
+
+When your test code uses helper functions, stack traces may only report the location within the
+helper, and not the location of the helper's caller. To get both, you need to wrap the helper with
+`stackWrapFunc`. See also `test/helpers.ts` for an example of how to wrap an entire module of
+helpers.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ directory into which to save logs and screenshots automatically after any failed
   - `MOCHA_WEBDRIVER_LOGTYPES`: comma-separated list of which [log types](https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/lib/logging_exports_Type.html)
 to enable, for `driver.fetchLogs()` and for `enableDebugCapture()`. Defaults to `browser,driver`.
 (Note: Supported by Chrome, but not Firefox, as of June 2019.)
+  - `MOCHA_WEBDRIVER_STACKTRACES`: Enhance stack traces with async frames, if set to non-empty
+value.
 
 ## Useful methods
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -8,6 +8,7 @@ import * as chrome from 'selenium-webdriver/chrome';
 import * as firefox from 'selenium-webdriver/firefox';
 import {getEnabledLogTypes, LogType} from './logs';
 import {serializeCalls} from './serialize-calls';
+import {stackWrapDriverMethods} from './stackTraces';
 import "./webdriver-plus";
 
 chai.use(chaiAsPromised);
@@ -26,6 +27,7 @@ export * from 'selenium-webdriver';
 
 // Re-export function that sets up an afterEach() hook to save screenshots of failed tests.
 export {enableDebugCapture} from './debugging';
+export {stackWrapFunc, stackWrapOwnMethods} from './stackTraces';
 export {LogType, logTypes} from './logs';
 
 /**
@@ -134,6 +136,10 @@ before(async function() {
     if (!(count > 0)) { throw new Error("Invalid value for MOCHA_WEBDRIVER_MAX_CALLS env var"); }
     const executor = driver.getExecutor();
     executor.execute = serializeCalls(executor.execute, count);
+  }
+
+  if (process.env.MOCHA_WEBDRIVER_STACKTRACES) {
+    stackWrapDriverMethods(driver);
   }
 });
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -81,6 +81,9 @@ before(async function() {
     logPrefs.setLevel(logType, logging.Level.INFO);
   }
 
+  // Add stack trace enhancement (no-op if MOCHA_WEBDRIVER_STACKTRACES isn't set).
+  stackWrapDriverMethods(driver);
+
   // Prepend node_modules/.bin to PATH, for chromedriver/geckodriver to be found.
   process.env.PATH = path.resolve("node_modules", ".bin") + ":" + process.env.PATH;
 
@@ -136,10 +139,6 @@ before(async function() {
     if (!(count > 0)) { throw new Error("Invalid value for MOCHA_WEBDRIVER_MAX_CALLS env var"); }
     const executor = driver.getExecutor();
     executor.execute = serializeCalls(executor.execute, count);
-  }
-
-  if (process.env.MOCHA_WEBDRIVER_STACKTRACES) {
-    stackWrapDriverMethods(driver);
   }
 });
 

--- a/lib/stackTraces.ts
+++ b/lib/stackTraces.ts
@@ -67,6 +67,9 @@ function cleanStack(err: Error, origErr: Error): Error {
   const origLines = origErr.stack!.split('\n');
   // Get the filename of this file (stackTraces.ts) from the first line of trace (it may differ
   // from __filename e.g. in ".js" vs ".ts" extension).
+  // Stack trace lines look like this:
+  // >>> at thenableWebDriverProxy.find (mocha-webdriver/lib/webdriver-plus.ts:192:17)
+  // So we parse out the filename as the part between "(" and ":".
   const match = origLines[1] ? origLines[1].match(/\(([^:]*):\d+/) : null;
   const filename = match ? match[1] : __filename;
   const origStack = origLines.slice(1)                    // Skip the fake Error's name/message

--- a/lib/stackTraces.ts
+++ b/lib/stackTraces.ts
@@ -47,7 +47,6 @@ function wrap(fn: any, objName?: string): any {
     // This object has a useful stack trace. If we catch an error after some async operation,
     // we'll append this useful stack trace to it.
     const origErr = new Error('stackTraces');
-    // console.log("In", fn.name, origErr.stack);
     const ret = fn.apply(this, arguments);
     // Do nothing special if it didn't return a promise, or returned the driver itself.
     if (typeof ret.catch !== 'function' || ret instanceof WebDriver) { return ret; }
@@ -63,7 +62,9 @@ function wrap(fn: any, objName?: string): any {
 // Combine err.stack with origErr.stack, with an attempt to make it readable and helpful.
 function cleanStack(err: Error, origErr: Error, fnName: string, objName?: string): Error {
   const origLines = origErr.stack!.split('\n');
-  const origStack = origLines.slice(2).join('\n');
+  const origStack = origLines.slice(1)                      // Skip the fake Error's name/message
+    .filter((line) => !line.includes(`(${__filename}:`))    // Omit lines referring to this file itself
+    .join('\n');
   if (!err.stack!.endsWith(origStack)) {
     const name = (objName ? objName + '.' : '') + fnName;
     err.stack += `\n   [[from ${name}]]\n` + origStack;

--- a/lib/stackTraces.ts
+++ b/lib/stackTraces.ts
@@ -1,0 +1,79 @@
+/**
+ * In node 12, proper stack traces are supposedly coming, but in node 10 stack traces printed by
+ * mocha for tests using async/await are often unhelpful.
+ *
+ * (In fact, node 12.2.0 does not seem to address some cases of lost stack traces, so this may
+ * still be needed with it. The unittests tests these situations.)
+ *
+ * In node 10, any function where an error is thrown after some `await` has returned, will include
+ * in the stack trace the location in that function, but not in its caller. If the function is
+ * wrapped using `stackWrapFunc()`, then its stack trace will be extended to include more info.
+ * Setting MOCHA_WEBDRIVER_STACKTRACES=1 will wrap all WebDriver and WebElement methods. If you
+ * call these via additional helpers, it is recommended to wrap the helpers too. See
+ * test/helpers.ts for an example.
+ *
+ * This module uses some hacks inspired by
+ * http://thecodebarbarian.com/async-stack-traces-in-node-js-12.html.
+ */
+import {WebDriver, WebElement, WebElementPromise} from './index';
+
+/**
+ * Wrap any function to report better stack traces.
+ * In errors thrown from the returned function, the part of stack leading up to its calls will
+ * be prefixed with [[from {func.name}]].
+ */
+export function stackWrapFunc<T extends any[], R>(fn: (...args: T) => R): (...args: T) => R {
+  return wrap(fn);
+}
+
+/**
+ * Wrap all methods in the given object, in-place. E.g. this gets applied to WebDriver.prototype.
+ * In errors thrown from these methods, the part of stack leading up to their calls will be
+ * prefixed with [[from {objName}.{methodName}]].
+ */
+export function stackWrapOwnMethods<T>(_obj: T, objName: string): T {
+  const obj = _obj as any;
+  for (const m of Object.getOwnPropertyNames(obj)) {
+    if (typeof obj[m] === 'function' && !m.endsWith('_') && !m.startsWith('_')) {
+      obj[m] = wrap(obj[m].origFunc || obj[m], objName);
+    }
+  }
+  return obj;
+}
+
+// Wrap a single function.
+function wrap(fn: any, objName?: string): any {
+  const wrapped = function(this: any) {
+    // This object has a useful stack trace. If we catch an error after some async operation,
+    // we'll append this useful stack trace to it.
+    const origErr = new Error('stackTraces');
+    // console.log("In", fn.name, origErr.stack);
+    const ret = fn.apply(this, arguments);
+    // Do nothing special if it didn't return a promise, or returned the driver itself.
+    if (typeof ret.catch !== 'function' || ret instanceof WebDriver) { return ret; }
+    // Otherwise, tack on to the stack the stack trace from origErr, with cleaning.
+    const ret2 = ret.catch((err: any) => { throw cleanStack(err, origErr, fn.name, objName); });
+    // And if it's a WebElementPromise, make sure we still return one.
+    return (ret instanceof WebElementPromise) ? new WebElementPromise(ret.getDriver(), ret2) : ret2;
+  };
+  wrapped.origFunc = fn;
+  return wrapped;
+}
+
+// Combine err.stack with origErr.stack, with an attempt to make it readable and helpful.
+function cleanStack(err: Error, origErr: Error, fnName: string, objName?: string): Error {
+  const origLines = origErr.stack!.split('\n');
+  const origStack = origLines.slice(2).join('\n');
+  if (!err.stack!.endsWith(origStack)) {
+    const name = (objName ? objName + '.' : '') + fnName;
+    err.stack += `\n   [[from ${name}]]\n` + origStack;
+  }
+  return err;
+}
+
+// This is called automatically when driver is created.
+export function stackWrapDriverMethods(_driver: WebDriver) {
+  stackWrapOwnMethods(WebDriver.prototype, 'WebDriver');
+  stackWrapOwnMethods(WebElement.prototype, 'WebElement');
+  stackWrapOwnMethods(WebElementPromise.prototype, 'WebElementPromise');
+}

--- a/lib/stackTraces.ts
+++ b/lib/stackTraces.ts
@@ -3,7 +3,7 @@
  * mocha for tests using async/await are often unhelpful.
  *
  * (In fact, node 12.2.0 does not seem to address some cases of lost stack traces, so this may
- * still be needed with it. The unittests tests these situations.)
+ * still be needed with it. The unittest tests these situations.)
  *
  * In node 10, any function where an error is thrown after some `await` has returned, will include
  * in the stack trace the location in that function, but not in its caller. If the function is
@@ -65,8 +65,12 @@ function wrap(fn: any): any {
 // Combine err.stack with origErr.stack, with an attempt to make it readable and helpful.
 function cleanStack(err: Error, origErr: Error): Error {
   const origLines = origErr.stack!.split('\n');
-  const origStack = origLines.slice(1)                      // Skip the fake Error's name/message
-    .filter((line) => !line.includes(`(${__filename}:`))    // Omit lines referring to this file itself
+  // Get the filename of this file (stackTraces.ts) from the first line of trace (it may differ
+  // from __filename e.g. in ".js" vs ".ts" extension).
+  const match = origLines[1] ? origLines[1].match(/\(([^:]*):\d+/) : null;
+  const filename = match ? match[1] : __filename;
+  const origStack = origLines.slice(1)                    // Skip the fake Error's name/message
+    .filter((line) => !line.includes(`(${filename}:`))    // Omit lines referring to this file itself
     .map((line) => line.replace(/^\s*at /, '$&[enhanced] '))
     .join('\n');
   if (!err.stack!.endsWith(origStack)) {

--- a/lib/stackTraces.ts
+++ b/lib/stackTraces.ts
@@ -52,7 +52,7 @@ function wrap(fn: any): any {
     const origErr = new Error('stackTraces');
     const ret = fn.apply(this, arguments);
     // Do nothing special if it didn't return a promise, or returned the driver itself.
-    if (typeof ret.catch !== 'function' || ret instanceof WebDriver) { return ret; }
+    if (!ret || typeof ret.catch !== 'function' || ret instanceof WebDriver) { return ret; }
     // Otherwise, tack on to the stack the stack trace from origErr, with cleaning.
     const ret2 = ret.catch((err: any) => { throw cleanStack(err, origErr); });
     // And if it's a WebElementPromise, make sure we still return one.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "lint": "tslint -p .",
     "prepack": "npm run build && npm run test && npm run lint",
-    "test": "mocha 'test/**/*.{js,ts}'",
+    "test": "MOCHA_WEBDRIVER_HEADLESS=1 MOCHA_WEBDRIVER_STACKTRACES=1 mocha 'test/**/*.{js,ts}'",
     "test-debug": "mocha 'test/**/*.{js,ts}' -b --no-exit"
   },
   "files": [

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -19,5 +19,5 @@ namespace helper {
   }
 }
 
-stackWrapOwnMethods(helper, 'helpers');
+stackWrapOwnMethods(helper);
 export = helper;

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,0 +1,23 @@
+/**
+ * This file is part of test-stackTraces.ts, and serves also as an illustration for how to
+ * organize helper methods. They can be placed in namespace (silencing tslint), wrapped in a
+ * single call, and imported in the same way as if they were exported directly.
+ */
+
+import {assert, driver, stackWrapOwnMethods} from '../lib';
+
+// tslint:disable-next-line:no-namespace
+namespace helper {
+  export async function helperFunc1() {
+    await driver.sleep(1);
+    assert.equal(1, 2);
+  }
+
+  export async function helperFunc2() {
+    await driver.sleep(1);
+    await driver.find('.nonexistent');
+  }
+}
+
+stackWrapOwnMethods(helper, 'helpers');
+export = helper;

--- a/test/test-stackTraces.ts
+++ b/test/test-stackTraces.ts
@@ -1,0 +1,78 @@
+import * as path from 'path';
+import {assert, driver, setUpDebugCapture} from '../lib';
+import {helperFunc1, helperFunc2} from './helpers';
+
+function getThisLineNum(): number {
+  const err = new Error();
+  Error.captureStackTrace(err, getThisLineNum);
+  const matches = err.stack!.match(/:(\d+)/) || [];
+  return parseInt(matches[1], 10);
+}
+
+describe('stackTraces', () => {
+  setUpDebugCapture();
+
+  function createDom() {
+    document.body.innerHTML = `<div id=".cls1">Hello</div>`;
+  }
+
+  before(async function() {
+    this.timeout(20000);
+    await driver.get('file://' + path.resolve(__dirname, 'blank.html'));
+    await driver.executeScript(createDom);
+  });
+
+  it('should report line in plain assert', async () => {
+    const line = getThisLineNum();
+    try {
+      assert.equal(1, 2);
+    } catch (e) {
+      assert.match(e.stack, new RegExp(`AssertionError:.*/test-stackTraces.ts:${line + 2}`, 's'),
+        `Stack trace does not include expected line number ${line + 2}`);
+    }
+  });
+
+  it('should report line in assert after async', async () => {
+    await driver.sleep(1);
+    const line = getThisLineNum();
+    try {
+      assert.equal(1, 2);
+    } catch (e) {
+      assert.match(e.stack, new RegExp(`AssertionError:.*/test-stackTraces.ts:${line + 2}`, 's'),
+        `Stack trace does not include expected line number ${line + 2}`);
+    }
+  });
+
+  it('should report line in assert in a called func', async () => {
+    await driver.sleep(1);
+    const line = getThisLineNum();
+    try {
+      await helperFunc1();
+    } catch (e) {
+      assert.match(e.stack, new RegExp(`AssertionError:.*/test-stackTraces.ts:${line + 2}`, 's'),
+        `Stack trace does not include expected line number ${line + 2}`);
+    }
+  });
+
+  it('should report line in failed webdriver operation', async () => {
+    await driver.sleep(1);
+    const line = getThisLineNum();
+    try {
+      await driver.find('.nonexistent');
+    } catch (e) {
+      assert.match(e.stack, new RegExp(`NoSuchElementError:.*/test-stackTraces.ts:${line + 2}`, 's'),
+        `Stack trace does not include expected line number ${line + 2}`);
+    }
+  });
+
+  it('should report line in failed webdriver operation in a called func', async () => {
+    await driver.sleep(1);
+    const line = getThisLineNum();
+    try {
+      await helperFunc2();
+    } catch (e) {
+      assert.match(e.stack, new RegExp(`NoSuchElementError:.*/test-stackTraces.ts:${line + 2}`, 's'),
+        `Stack trace does not include expected line number ${line + 2}`);
+    }
+  });
+});

--- a/test/test-stackTraces.ts
+++ b/test/test-stackTraces.ts
@@ -1,16 +1,19 @@
 import * as path from 'path';
-import {assert, driver, setUpDebugCapture, stackWrapFunc} from '../lib';
+import {assert, driver, enableDebugCapture, stackWrapFunc} from '../lib';
 import {helperFunc1, helperFunc2} from './helpers';
 
 function getThisLineNum(): number {
   const err = new Error();
   Error.captureStackTrace(err, getThisLineNum);
+  // Stack trace lines look like this:
+  // >>> at thenableWebDriverProxy.find (mocha-webdriver/lib/webdriver-plus.ts:192:17)
+  // So we parse out the line number as the number following ":".
   const matches = err.stack!.match(/:(\d+)/) || [];
   return parseInt(matches[1], 10);
 }
 
 describe('stackTraces', () => {
-  setUpDebugCapture();
+  enableDebugCapture();
 
   function createDom() {
     document.body.innerHTML = `<div id=".cls1">Hello</div>`;


### PR DESCRIPTION
- Includes a unittest that stack traces include useful locations.
- stackWrapFunc / stackWrapOwnMethods exported for wrapping helpers.
