### PR TITLE
Add support for regexp flags in the findContent family of functions

### DIFF
--- a/lib/webdriver-plus.ts
+++ b/lib/webdriver-plus.ts
@@ -168,9 +168,9 @@ async function findContentIfPresent(driver: WebDriver, finder: WebElement|null,
   return await driver.executeScript<WebElement>(() => {
     const finder = (arguments[0] || window.document);
     const elements = [...finder.querySelectorAll(arguments[1])];
-    const contentRE = new RegExp(arguments[2]);
+    const contentRE = new RegExp(arguments[2].source, arguments[2].flags);
     return elements.find((el) => contentRE.test(el.innerText));
-  }, finder, selector, contentRE.source);
+  }, finder, selector, {source: contentRE.source, flags: contentRE.flags});
 }
 
 async function findClosestHelper(driver: WebDriver, finder: WebElement, selector: string): Promise<WebElement> {

--- a/test/test-webdriver-plus.ts
+++ b/test/test-webdriver-plus.ts
@@ -115,6 +115,11 @@ describe('webdriver-plus', () => {
       assert.equal(elemText, 'Foo');
     });
 
+    it('should support flags in regex', async function() {
+      assert.equal(await driver.findContent('.cls1', /b/i).getText(), 'Bye');
+      assert.equal(await driver.findContent('.cls1', /k$/i).getText(), 'OK');
+    });
+
     it('should find the closest matching ancestor with element.findClosest()', async function() {
       const child = await driver.find(".cls2");
       await assert.match(await child.findClosest('#id1').getText(), /Hello/);
@@ -136,7 +141,7 @@ describe('webdriver-plus', () => {
   describe('WebElement', function() {
     function createDom() {
       document.body.innerHTML = `
-        <style>#btn:hover { background-color: pink; color: green; }</style>
+        <style>#btn { color: black; } #btn:hover { background-color: pink; color: green; }</style>
         <div id="id1" class="cls0 test0">
           <input id="inp" type="text">
           <button id="btn">Hello</button>


### PR DESCRIPTION
`driver.findContent('div', /foo/i)` was not matching `<div>FOO</div>` because it was ignoring the regexp flags. This commit fixes it.