### PR TITLE
Fixes findContent in the repl.

### DIFF
--- a/lib/webdriver-plus.ts
+++ b/lib/webdriver-plus.ts
@@ -168,11 +168,13 @@ async function findContentIfPresent(driver: WebDriver, finder: WebElement|null,
   // credit for the regexp escape:
   // https://makandracards.com/makandra/15879-javascript-how-to-generate-a-regular-expression-from-a-string
 
-  // WARN: Desciminating with `content instanceof RegExp ? ... : ... ;` was causing issues when
+  // WARN: Discriminating with `content instanceof RegExp ? ... : ... ;` was causing issues when
   // called from the repl (for instance `node > driver.findContent('.foo', /BAR/)` was
   // failing). It's as if repl uses its own instance of the RegExp class, making content not an
   // instance of the RegExp in this context. It's something to keep in mind when implementating
   // function that accepts built in objects (Date, URL, ...).
+  // tslint:disable-next-line:max-line-length
+  // Useful link: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_context_(e.g._frames_or_windows)
   const contentRE = typeof content === 'string' ?
     new RegExp(content.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')) :
     content;

--- a/lib/webdriver-plus.ts
+++ b/lib/webdriver-plus.ts
@@ -167,9 +167,15 @@ async function findContentIfPresent(driver: WebDriver, finder: WebElement|null,
 
   // credit for the regexp escape:
   // https://makandracards.com/makandra/15879-javascript-how-to-generate-a-regular-expression-from-a-string
-  const contentRE = content instanceof RegExp ?
-    content :
-    new RegExp(content.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'));
+
+  // WARN: Desciminating with `content instanceof RegExp ? ... : ... ;` was causing issues when
+  // called from the repl (for instance `node > driver.findContent('.foo', /BAR/)` was
+  // failing). It's as if repl uses its own instance of the RegExp class, making content not an
+  // instance of the RegExp in this context. It's something to keep in mind when implementating
+  // function that accepts built in objects (Date, URL, ...).
+  const contentRE = typeof content === 'string' ?
+    new RegExp(content.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')) :
+    content;
 
   // tslint:disable:no-shadowed-variable
   return await driver.executeScript<WebElement>(() => {


### PR DESCRIPTION
Running `node> driver.findContent('.foo', /BAR/);` is broken. The culprit is in mocha-webdriver in `lib/webdriver-plus.ts`:
```
const contentRE = content instanceof RegExp ?
   content :
   new RegExp(content.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'));
```
This fails when making a call from the repl as `node> driver.find('.foo', /Bar/);`, it fails to recognize `/Bar/` as being an instance of RegExp, so it treat it as a `string` and fails for not having a `.replace` function. The problem could be that the `repl` uses it's own RegExp constructor, making `content instanceof RegExp` inoperant in this context. One solution implemented in this PR is to change to
```
const contentRE = typeof content  === 'string' ?
   new RegExp(content.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')) :
   content;
```
.
I've thought of other solutions, such as passing the `RegExp` constructor to the repl context. It does solves the issues when using `driver.findContent('.foo', new RegExp('BAR'));` but not when using `/BAR/`. Maybe there could be a solution by customizing further the repl eval function maybe parsing argument, but lack of documentation makes it hard.