### PR TITLE
expose a method for creating a driver instance

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -80,7 +80,8 @@ const noexit: boolean = process.argv.includes("--no-exit") || process.argv.inclu
 
 /**
  * Create a driver, with all command-line options applied.  Extra options can be passed
- * in as a parameter.
+ * in as a parameter.  For example, {extraArgs: ['user-agent=notscape']} would set the
+ * user agent in chrome.
  */
 export async function createDriver(options: {extraArgs?: string[]} = {}): Promise<WebDriver> {
   // Set up browser options.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -78,21 +78,16 @@ export function useServer(server: IMochaServer) {
 // mocha, and we use it too to start up a REPL when this option is used.
 const noexit: boolean = process.argv.includes("--no-exit") || process.argv.includes('-E');
 
-// Start up the webdriver and serve files that its browser will see.
-before(async function() {
-  this.timeout(20000);      // Set a longer default timeout.
-
+/**
+ * Create a driver, with all command-line options applied.  Extra options can be passed
+ * in as a parameter.
+ */
+export async function createDriver(options: {extraArgs?: string[]} = {}): Promise<WebDriver> {
   // Set up browser options.
   const logPrefs = new logging.Preferences();
   for (const logType of getEnabledLogTypes()) {
     logPrefs.setLevel(logType, logging.Level.INFO);
   }
-
-  // Add stack trace enhancement (no-op if MOCHA_WEBDRIVER_STACKTRACES isn't set).
-  stackWrapDriverMethods(driver);
-
-  // Prepend node_modules/.bin to PATH, for chromedriver/geckodriver to be found.
-  process.env.PATH = npmRunPath({cwd: __dirname});
 
   const chromeOpts = new chrome.Options();
   // Typings for Firefox options are incomplete, so supplement them with Chrome's typings.
@@ -123,6 +118,10 @@ before(async function() {
     firefoxOpts.addArguments("-width", widthStr, "-height", heightStr);
   }
 
+  if (options.extraArgs) {
+    chromeOpts.addArguments(...options.extraArgs);
+    firefoxOpts.addArguments(...options.extraArgs);
+  }
   if (process.env.MOCHA_WEBDRIVER_ARGS) {
     const args = process.env.MOCHA_WEBDRIVER_ARGS.trim().split(/\s+/);
     chromeOpts.addArguments(...args);
@@ -136,7 +135,7 @@ before(async function() {
   const chromeService = process.env.MOCHA_WEBDRIVER_IGNORE_CHROME_VERSION ?
     new chrome.ServiceBuilder().addArguments("--disable-build-check") : null;
 
-  driver = new Builder()
+  const newDriver = new Builder()
     .forBrowser('firefox')
     .setLoggingPrefs(logPrefs)
     .setChromeOptions(chromeOpts)
@@ -144,7 +143,7 @@ before(async function() {
     .setFirefoxOptions(firefoxOpts)
     .build();
   // If driver fails to start, this will let us notice and abort quickly.
-  await driver.getSession();
+  await newDriver.getSession();
 
   // If requested, limit the max number of parallel in-flight selenium calls. This is needed for
   // selenium-standalone, which can't cope with more than a few calls. A limit like 5 works fine.
@@ -152,9 +151,23 @@ before(async function() {
   if (process.env.MOCHA_WEBDRIVER_MAX_CALLS) {
     const count = parseInt(process.env.MOCHA_WEBDRIVER_MAX_CALLS, 10);
     if (!(count > 0)) { throw new Error("Invalid value for MOCHA_WEBDRIVER_MAX_CALLS env var"); }
-    const executor = driver.getExecutor();
+    const executor = newDriver.getExecutor();
     executor.execute = serializeCalls(executor.execute, count);
   }
+  return newDriver;
+}
+
+// Start up the webdriver and serve files that its browser will see.
+before(async function() {
+  this.timeout(20000);      // Set a longer default timeout.
+
+  // Add stack trace enhancement (no-op if MOCHA_WEBDRIVER_STACKTRACES isn't set).
+  stackWrapDriverMethods();
+
+  // Prepend node_modules/.bin to PATH, for chromedriver/geckodriver to be found.
+  process.env.PATH = npmRunPath({cwd: __dirname});
+
+  driver = await createDriver();
 });
 
 // Helper to return whether the given suite had any failures.
@@ -167,6 +180,7 @@ function suiteFailed(ctx: Mocha.Context): boolean {
 
 // Quit the webdriver and stop serving files, unless we failed and --no-exit is given.
 after(async function() {
+  this.timeout(6000);
   const testParent = this.test!.parent!;
   if (suiteFailed(this) && noexit) {
     const files = new Set<string>();

--- a/lib/stackTraces.ts
+++ b/lib/stackTraces.ts
@@ -83,7 +83,7 @@ function cleanStack(err: Error, origErr: Error): Error {
 }
 
 // This is called automatically when driver is created.
-export function stackWrapDriverMethods(_driver: WebDriver) {
+export function stackWrapDriverMethods() {
   stackWrapOwnMethods(WebDriver.prototype);
   stackWrapOwnMethods(WebElement.prototype);
   stackWrapOwnMethods(WebElementPromise.prototype);

--- a/test/test-create-driver.ts
+++ b/test/test-create-driver.ts
@@ -1,0 +1,42 @@
+import * as path from 'path';
+import {assert, createDriver, enableDebugCapture} from '../lib';
+
+describe('createDriver', () => {
+  enableDebugCapture();
+
+  function createDom(name: string) {
+    document.body.innerHTML = `<h1>${name}</h1>`;
+  }
+
+  it('can create multiple drivers', async function() {
+    this.timeout(20000);
+    const driver1 = await createDriver();
+    const driver2 = await createDriver();
+    try {
+      await driver1.get('file://' + path.resolve(__dirname, 'blank.html'));
+      await driver2.get('file://' + path.resolve(__dirname, 'blank.html'));
+      await driver1.executeScript(createDom, 'driver1');
+      await driver2.executeScript(createDom, 'driver2');
+      await driver1.findContentWait('body', 'driver1', 1000);
+      await driver2.findContentWait('body', 'driver2', 1000);
+    } finally {
+      await driver1.quit();
+      await driver2.quit();
+    }
+  });
+
+  it('can set custom driver options', async function() {
+    if (process.env.SELENIUM_BROWSER !== 'chrome') { this.skip(); }
+    this.timeout(20000);
+    const driver = await createDriver({
+      extraArgs: ['user-agent=notscape']
+    });
+    try {
+      await driver.get('file://' + path.resolve(__dirname, 'blank.html'));
+      const userAgent = await driver.executeScript('return navigator.userAgent');
+      assert.equal(userAgent, 'notscape');
+    } finally {
+      await driver.quit();
+    }
+  });
+});


### PR DESCRIPTION
This adds a `createDriver` method that allows creating multiple
driver instances with different browser options.  This is handy
for testing with different user agents.