### PR TITLE
add MOCHA_WEBDRIVER_NO_CONTROL_BANNER

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ to enable, for `driver.fetchLogs()` and for `enableDebugCapture()`. Defaults to 
   - `MOCHA_WEBDRIVER_STACKTRACES`: Enhance stack traces with async frames, if set to a non-empty
 value.
   - `MOCHA_WEBDRIVER_IGNORE_CHROME_VERSION`: Disable chromedriver's check that it supports the installed version of Chrome. Normally the installed chromedriver (controlled by the version in `yarn.lock`) must [match Chrome's version](https://chromedriver.chromium.org/downloads/version-selection). When tests are run by different developers and test environments, that can cause difficulties. On the other hand, incompatible behavior is rare, so this option offers a practical workaround.
+  - `MOCHA_WEBDRIVER_NO_CONTROL_BANNER`: suppress the "Chrome is being controlled by automated test software" banner.
 
 ## Useful methods
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -94,6 +94,13 @@ export async function createDriver(options: {extraArgs?: string[]} = {}): Promis
   // Typings for Firefox options are incomplete, so supplement them with Chrome's typings.
   const firefoxOpts = new firefox.Options() as firefox.Options & chrome.Options;
 
+  // Optionally suppress the "Chrome is being controlled by automated test software" banner.
+  // At the time of writing, on page reloads this can result on early clicks being missed,
+  // so it can be helpful to just suppress it entirely.
+  if (process.env.MOCHA_WEBDRIVER_NO_CONTROL_BANNER) {
+    chromeOpts.excludeSwitches("enable-automation");
+  }
+
   // Pay attention to the environment variables (documented in README).
   if (process.env.MOCHA_WEBDRIVER_HEADLESS) {
     chromeOpts.headless();


### PR DESCRIPTION
This adds an option to suppress the `Chrome is being controlled by automated test software` banner.

This banner is currently causing arcane trouble on page reloads, with early clicks not necessarily reaching their target.