### PR TITLE
support running mocha in parallel mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ to enable, for `driver.fetchLogs()` and for `enableDebugCapture()`. Defaults to 
 value.
   - `MOCHA_WEBDRIVER_IGNORE_CHROME_VERSION`: Disable chromedriver's check that it supports the installed version of Chrome. Normally the installed chromedriver (controlled by the version in `yarn.lock`) must [match Chrome's version](https://chromedriver.chromium.org/downloads/version-selection). When tests are run by different developers and test environments, that can cause difficulties. On the other hand, incompatible behavior is rare, so this option offers a practical workaround.
   - `MOCHA_WEBDRIVER_NO_CONTROL_BANNER`: suppress the "Chrome is being controlled by automated test software" banner. This banner may cause Chrome (as of version 79) to ignore clicks immediately after loading a page.
+  - `MOCHA_WEBDRIVER_SKIP_CLEANUP`: stops the library from cleaning up the driver, or doing any of the special termination behavior. When running tests in parallel, mocha will call set up and clean up at the test file level, so there may be a speed-up possible by skipping clean up and reusing the driver within individual test worker processes. But you'll need to clean up browser processes yourself.
+
+If running mocha with `--parallel` set, the library won't be automatically
+initialized and cleaned up; you'll need to set [root hooks](https://mochajs.org/#defining-a-root-hook-plugin) to the
+values given by `getMochaHooks()`.
 
 ## Useful methods
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "tslint -p .",
     "prepack": "npm run build && npm run test && npm run lint",
     "test": "MOCHA_WEBDRIVER_HEADLESS=1 mocha test",
+    "test-parallel": "MOCHA_WEBDRIVER_HEADLESS=1 mocha test --parallel --jobs=4",
     "test-debug": "mocha test -b --no-exit"
   },
   "files": [

--- a/test/init-mocha-webdriver.js
+++ b/test/init-mocha-webdriver.js
@@ -14,3 +14,8 @@ if (process.env.MOCHA_WEBDRIVER_IGNORE_CHROME_VERSION === undefined) {
 if (!process.env.SELENIUM_BROWSER) {
   process.env.SELENIUM_BROWSER = "chrome";
 }
+
+if (process.env.MOCHA_WORKER_ID !== undefined) {
+  const {getMochaHooks} = require('../lib');
+  exports.mochaHooks = getMochaHooks();
+}


### PR DESCRIPTION
This library doesn't work as is when mocha is configured to run parallel jobs. The biggest change is how hooks work; there are now separate processes coordinated by mocha that have their own life-cycle. The library can't even be imported correctly in parallel mode, since it attempts to use `before` and `after`, and there is now a context in which those are not defined.

This commit makes it possible to import the library in contexts where `before` and `after` are not yet defined, and to access the needed methods for starting up and cleaning up without immediately invoking them. The user can then install the hooks in the way that parallel operation requires, see:
  https://mochajs.org/#defining-a-root-hook-plugin

In parallel mode, the before/after hooks for the library will run at the beginning and end of each test file. This imposes a cost, since the browser has a non-trivial startup time. If the user is willing to clean up (or ignore) browser processes, they can set a flag to skip browser shutdowns at the end of each test file.

Perhaps someday mocha will have hooks for the lifecycle of worker processes, and then a cleaner solution will be possible.

Some debugging functionality of mocha-webdriver doesn't make sense in a multi-process scenario - I haven't touched this. Debugging will be best done without parallelism, this tweak is targetted at use in CI workflows.