### PR TITLE
Fix usage of driver variable in repl, for interactive debugging after test failure

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -240,8 +240,8 @@ export async function afterMochaWebdriverTests(this: Mocha.Context) {
     startRepl(Array.from(files));
   } else {
     await cleanup(this);
+    _driver = undefined;
   }
-  _driver = undefined;
 }
 
 // Do not attempt to set the hooks if `before` is not defined, or if


### PR DESCRIPTION
Trying to use 'driver' in interactive repl has been producing "WebDriver accessed before initialization"