### PR TITLE
Adds missing log file when beforeAll errors

### DIFF
--- a/lib/debugging.ts
+++ b/lib/debugging.ts
@@ -5,6 +5,41 @@ import * as path from 'path';
 import {driver} from './index';
 import {getEnabledLogTypes, saveLogs} from './logs';
 
+function getTestSuiteHierarchy(test: Mocha.Runnable): Mocha.Suite[] {
+  const suites: Mocha.Suite[] = [];
+  let parent = test.parent;
+  while (parent) {
+    suites.push(parent);
+    parent = parent.parent;
+  }
+  return suites;
+}
+
+function sanitizeStringForFilename(name: string): string {
+  return name
+      .replace(/\s/g, '-')
+      .replace(/[^A-Za-z0-9]/g, '')
+      ;
+}
+
+function getFilePrefixForTest(test: Mocha.Runnable): string {
+  const fileName = sanitizeStringForFilename(
+      test.file ? path.basename(test.file, path.extname(test.file)) : ""
+  );
+  const suiteNames = getTestSuiteHierarchy(test)
+      .map((suite) => sanitizeStringForFilename(suite.title.trim()))
+      .filter((suite) => suite);
+
+  return `${fileName}-${suiteNames.join('-')}`;
+}
+
+function suiteHasTestFailures(suite: Mocha.Suite): boolean {
+  const thisSuiteHasFailures = suite.tests.some((test) => test.isFailed());
+  const nestedSuitesHaveFailures = suite.suites.some((childSuite) => suiteHasTestFailures(childSuite));
+
+  return thisSuiteHasFailures || nestedSuitesHaveFailures;
+}
+
 /**
  * Adds an afterEach() hook to the current test suite to save logs and screenshots after failed
  * tests. These are saved only if `MOCHA_WEBDRIVER_LOGDIR` variable is set, and named:
@@ -33,13 +68,33 @@ export function enableDebugCapture() {
     // Take snapshots after each failed test case.
     const test = this.currentTest!;
     if (test.state !== 'passed' && !test.pending) {
-      // If test filename is available, name screenshots as "screenshot-testName-N.png"
-      const testName = test.file ? path.basename(test.file, path.extname(test.file)) : "unnamed";
+      const filePrefix = getFilePrefixForTest(test);
       if (process.env.MOCHA_WEBDRIVER_LOGDIR) {
-        await driver.saveScreenshot(`${testName}-screenshot-{N}.png`);
+        await driver.saveScreenshot(`${filePrefix}-screenshot-{N}.png`);
         for (const logType of getEnabledLogTypes()) {
           const messages = await driver.fetchLogs(logType);
-          await saveLogs(messages, `${testName}-${logType}-{N}.log`);
+          await saveLogs(messages, `${filePrefix}-${logType}-{N}.log`);
+        }
+      }
+    }
+  });
+
+  after(async function() {
+    // Dump any remaining log files. Certain error cases leave lingering logs, such as errors in before()
+    // Retrieve the test suite the current after() hook is installed in.
+    const hook = this.test;
+    const suite = hook?.parent;
+    if (!suite) { return; }
+
+    const shouldSaveLogs = suiteHasTestFailures(suite) && process.env.MOCHA_WEBDRIVER_LOGDIR;
+
+    if (shouldSaveLogs) {
+      const filePrefix = getFilePrefixForTest(hook);
+      for (const logType of getEnabledLogTypes()) {
+        const messages = await driver.fetchLogs(logType);
+        // Only save if there's messages, as there's potential for a lot of empty files here.
+        if (messages.length > 0) {
+          await saveLogs(messages, `${filePrefix}-afterSuiteCompleted-${logType}-{N}.log`);
         }
       }
     }

--- a/lib/debugging.ts
+++ b/lib/debugging.ts
@@ -17,18 +17,18 @@ function getTestSuiteHierarchy(test: Mocha.Runnable): Mocha.Suite[] {
 
 function sanitizeStringForFilename(name: string): string {
   return name
-      .replace(/\s/g, '-')
-      .replace(/[^A-Za-z0-9]/g, '')
-      ;
+    .replace(/\s/g, '-')
+    .replace(/[^A-Za-z0-9]/g, '')
+    ;
 }
 
 function getFilePrefixForTest(test: Mocha.Runnable): string {
   const fileName = sanitizeStringForFilename(
-      test.file ? path.basename(test.file, path.extname(test.file)) : ""
+    test.file ? path.basename(test.file, path.extname(test.file)) : ""
   );
   const suiteNames = getTestSuiteHierarchy(test)
-      .map((suite) => sanitizeStringForFilename(suite.title.trim()))
-      .filter((suite) => suite);
+    .map((suite) => sanitizeStringForFilename(suite.title.trim()))
+    .filter((suite) => suite);
 
   return `${fileName}-${suiteNames.join('-')}`;
 }


### PR DESCRIPTION
In the current version, logs are saved using an `afterEach` hook that fires after each test.

This hook doesn't fire when errors occur in a `before` hook, so any errors caught by the Selenium driver don't get persisted.

This PR adds an `after` hook, which persists any logs that happen after the test suite has finished executing, including if there's an error in `before` hooks. 

This should help address CI issues in gristlabs/grist-core, by giving access to additional driver logs.